### PR TITLE
Fix Quantiseq error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ write.table(counts.TPM.normalized, "GEMDeCan_deconvolution/inputs/file_name.txt"
 ```
 Note that the input file should be saved in `inputs/` directory. Additionally, go to the `snakemake.yml` file and add the name of your input file (without extension) in the `Mixtures` section. 
 
-If your gene expression matrix includes non coding genes associated with C/D Boxes (e.g. SNORD116-28) remove them before running the pipeline.
-
 ### Installation
 Snakemake allows for a very efficient and user friendly way of using pipelines. It is designed so all you need to install is _mamba_ which is required to install Snakemake
 Note that officially only Linux is supported for this pipeline. This also requires an Internet connection in order to use _mamba_ auto-generated environments for all necessary software and packages.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ gene    Sample1   Sample2   Sample3
  g4      7.2       9.1       0.6
 ```
 
-Example of how to save the input file from R: 
+Once this format is achieved, you can save the input file from R using: 
 ```
 write.table(counts.TPM.normalized, "GEMDeCan_deconvolution/inputs/file_name.txt", quote = F, sep = "\t", row.names = F)
 ```
+Note that the input file should be saved in `inputs/` directory. Additionally, go to the `snakemake.yml` file and add the name of your input file (without extension) in the `Mixtures` section. 
+
 If your gene expression matrix includes non coding genes associated with C/D Boxes (e.g. SNORD116-28) remove them before running the pipeline.
 
 ### Installation
@@ -70,7 +72,7 @@ After running GEMDeCan succesfully for the first time, go to the files `scripts/
 - Go to the file `snakemake.yml` and add the name of your input file in the section `Mixtures`
 
 ### Run GEMDeCan
-`sudo snakemake --cores 8 all`
+Either `sudo snakemake --cores 8 all` or `sudo path_where_snakemake_is_located --cores 8 all` depending if snakemake has been installed locally or not.
 
 ## CIBERSORTX
 CIBERSORTx is included in the deconvolution methods in the GEMDeCan pipeline, but it's not run by default as it's not an open-source program. 

--- a/scripts/deconvolution/deconvolution_algorithms.R
+++ b/scripts/deconvolution/deconvolution_algorithms.R
@@ -2,8 +2,14 @@
 r = getOption("repos")
 r["CRAN"] = "https://cloud.r-project.org/"
 options(repos = r)
-install.packages(c("sass", "devtools", "BiocManager")
-BiocManager::install(c("EpiDISH", "DeconRNASeq"))
+
+if (!require("BiocManager", quietly = TRUE))
+  install.packages("BiocManager")
+BiocManager::install(version = "3.16", ask = F)
+install.packages("class")
+BiocManager::install("EpiDISH")
+BiocManager::install("DeconRNASeq", force = T)
+install.packages(c("sass", "devtools"))
 devtools::install_github('dviraran/xCell')
 devtools::install_github("ebecht/MCPcounter",ref="master", subdir="Source")
 remotes::install_github("icbi-lab/immunedeconv")
@@ -27,6 +33,9 @@ suppressPackageStartupMessages({
 })
 
 computeQuantiseq <- function(TPM_matrix) {
+  
+  TPM_matrix = TPM_matrix[rownames(TPM_matrix)%in%rownames(immunedeconv::dataset_racle$expr_mat),]
+  
   quantiseq <- as_tibble(deconvolute(TPM_matrix, "quantiseq")) %>%
     pivot_longer(-cell_type) %>%
     pivot_wider(names_from = cell_type, values_from = value) %>%


### PR DESCRIPTION
The problem is related to quantiseq, check https://github.com/omnideconv/immunedeconv/issues/146

The fixing involves looking for automatic commonalities between the genes from the input matrix and the genes provided by the signatures of quantiseq. This change is only applied for this method, other methods of deconvolution will work as they were working before.